### PR TITLE
Remove `bslib` dep because it's not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "rooibos-roku": "5.2.3",
     "undent": "0.1.0",
     "roku-deploy": "3.7.0",
-    "roku-log-bsc-plugin": "0.6.1",
-    "bslib": "1.0.0"
+    "roku-log-bsc-plugin": "0.6.1"
   },
   "scripts": {
     "build-tests": "npx bsc",


### PR DESCRIPTION
Removes the `bslib` npm dependency because that isn't necessary to be installed in client projects, only in ropm modules. Plus, this dependency points to a non-existent npm package. 